### PR TITLE
Implement schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,17 @@ scima up --driver hana --dsn "hdb://user:pass@host:30015" --migrations-dir ./mig
 scima status --driver hana --dsn "hdb://user:pass@host:30015" --migrations-dir ./migrations
 
 # Postgres example
-scima init --driver postgres --dsn "postgres://user:pass@localhost:5432/mydb?sslmode=disable" --migrations-dir ./migrations
 scima up --driver postgres --dsn "postgres://user:pass@localhost:5432/mydb?sslmode=disable" --migrations-dir ./migrations
 scima status --driver postgres --dsn "postgres://user:pass@localhost:5432/mydb?sslmode=disable" --migrations-dir ./migrations
 ```
 
 ## Migration files
-Create paired files for each version:
 ```
 0010_create_users_table.up.sql
 0010_create_users_table.down.sql
 ```
 
-### Schema placeholders
-
 You can write portable migrations using schema placeholders that are substituted at runtime:
-
 | Placeholder     | Description |
 |-----------------|-------------|
 | `{{schema}}`    | Required schema name (error if `--schema` not provided) |
@@ -43,6 +38,21 @@ You can write portable migrations using schema placeholders that are substituted
 Examples:
 
 ```sql
+
+
+## How schema is used
+
+The `--schema` flag serves two purposes:
+
+1. **Migration tracking table**: The schema is used to qualify the migration bookkeeping table (e.g., `schema_migrations` becomes `<schema>.schema_migrations`).
+2. **SQL placeholders**: Any migration SQL file containing the placeholders `{{schema}}` or `{{schema?}}` will have these tokens replaced with the provided schema value (or omitted if not set and using the optional form).
+
+This allows you to:
+- Track migrations in a schema-specific table
+- Write portable migration SQL that adapts to different schemas without duplicating files
+
+**Escaping placeholders:**
+To prevent substitution and keep the literal token in your SQL, prefix the placeholder with a single backslash (e.g., `\{{schema}}`). This is a literal backslash in your SQL file, not Go string escaping.
 -- Uses required schema placeholder
 CREATE TABLE {{schema}}.users (
 	id BIGSERIAL PRIMARY KEY,

--- a/cmd/scima/main.go
+++ b/cmd/scima/main.go
@@ -26,7 +26,7 @@ func addGlobalFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&driver, "driver", "hana", "Database driver/dialect (hana, pg, mysql, sqlite, etc.)")
 	cmd.PersistentFlags().StringVar(&dsn, "dsn", "", "Database DSN / connection string")
 	cmd.PersistentFlags().StringVar(&migrationsDir, "migrations-dir", "./migrations", "Directory containing migration files")
-	cmd.PersistentFlags().StringVar(&schema, "schema", "", "Optional database schema for migration tracking table")
+	cmd.PersistentFlags().StringVar(&schema, "schema", "", "Optional database schema for migration tracking table and SQL placeholders ({{schema}}, {{schema?}})")
 }
 
 func init() {

--- a/internal/migrate/migrator.go
+++ b/internal/migrate/migrator.go
@@ -4,6 +4,7 @@ package migrate
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/scima/scima/internal/dialect"
 )
@@ -36,7 +37,11 @@ func (m *Migrator) Status(ctx context.Context) (map[int64]bool, error) {
 // ApplyUp applies pending up migrations.
 func (m *Migrator) ApplyUp(ctx context.Context, ups []MigrationFile) error {
 	for _, up := range ups {
-		if _, err := m.Conn.ExecContext(ctx, up.SQL); err != nil {
+		expanded, err := expandPlaceholders(up.SQL, m.Schema)
+		if err != nil {
+			return fmt.Errorf("placeholder expansion up %d: %w", up.Version, err)
+		}
+		if _, err := m.Conn.ExecContext(ctx, expanded); err != nil {
 			return fmt.Errorf("apply up %d failed: %w", up.Version, err)
 		}
 		if err := m.Dialect.InsertVersion(ctx, m.Conn, m.Schema, up.Version); err != nil {
@@ -49,7 +54,11 @@ func (m *Migrator) ApplyUp(ctx context.Context, ups []MigrationFile) error {
 // ApplyDown applies downs.
 func (m *Migrator) ApplyDown(ctx context.Context, downs []MigrationFile) error {
 	for _, down := range downs {
-		if _, err := m.Conn.ExecContext(ctx, down.SQL); err != nil {
+		expanded, err := expandPlaceholders(down.SQL, m.Schema)
+		if err != nil {
+			return fmt.Errorf("placeholder expansion down %d: %w", down.Version, err)
+		}
+		if _, err := m.Conn.ExecContext(ctx, expanded); err != nil {
 			return fmt.Errorf("apply down %d failed: %w", down.Version, err)
 		}
 		if err := m.Dialect.DeleteVersion(ctx, m.Conn, m.Schema, down.Version); err != nil {
@@ -57,4 +66,56 @@ func (m *Migrator) ApplyDown(ctx context.Context, downs []MigrationFile) error {
 		}
 	}
 	return nil
+}
+
+const (
+	requiredSchemaToken = "{{schema}}"
+	optionalSchemaToken = "{{schema?}}"
+)
+
+// expandPlaceholders substitutes schema tokens in SQL.
+// {{schema}} requires a non-empty schema; {{schema?}} inserts schema plus dot or nothing.
+func expandPlaceholders(sql string, schema string) (string, error) {
+	// We process with a manual scan to support escaping via backslash: \{{schema}} or \{{schema?}} remain literal.
+	// Strategy: iterate runes, detect backslash before placeholder start; build output.
+	var b strings.Builder
+	// Precompute for efficiency.
+	req := requiredSchemaToken
+	opt := optionalSchemaToken
+	for i := 0; i < len(sql); {
+		// Handle escaped required placeholder
+		if i+1+len(req) <= len(sql) && sql[i] == '\\' && sql[i+1:i+1+len(req)] == req {
+			b.WriteString(req) // drop escape, keep literal token
+			i += 1 + len(req)
+			continue
+		}
+		// Handle escaped optional placeholder
+		if i+1+len(opt) <= len(sql) && sql[i] == '\\' && sql[i+1:i+1+len(opt)] == opt {
+			b.WriteString(opt)
+			i += 1 + len(opt)
+			continue
+		}
+		// Unescaped optional
+		if i+len(opt) <= len(sql) && sql[i:i+len(opt)] == opt {
+			if schema != "" {
+				b.WriteString(schema)
+				b.WriteByte('.')
+			}
+			i += len(opt)
+			continue
+		}
+		// Unescaped required
+		if i+len(req) <= len(sql) && sql[i:i+len(req)] == req {
+			if schema == "" {
+				return "", fmt.Errorf("%s used but schema not set", requiredSchemaToken)
+			}
+			b.WriteString(schema)
+			i += len(req)
+			continue
+		}
+		// Default: copy one byte
+		b.WriteByte(sql[i])
+		i++
+	}
+	return b.String(), nil
 }

--- a/internal/migrate/migrator.go
+++ b/internal/migrate/migrator.go
@@ -12,17 +12,25 @@ import (
 type Migrator struct {
 	Conn    dialect.Conn
 	Dialect dialect.Dialect
+	Schema  string // optional schema qualifier
 }
 
 // NewMigrator creates a new Migrator for the given dialect and connection.
-func NewMigrator(d dialect.Dialect, c dialect.Conn) *Migrator { return &Migrator{Conn: c, Dialect: d} }
+func NewMigrator(d dialect.Dialect, c dialect.Conn, schema string) *Migrator {
+	return &Migrator{Conn: c, Dialect: d, Schema: schema}
+}
+
+// EnsureMigrationTable ensures the migration tracking table exists.
+func (m *Migrator) EnsureMigrationTable(ctx context.Context) error {
+	return m.Dialect.EnsureMigrationTable(ctx, m.Conn, m.Schema)
+}
 
 // Status returns applied version set.
 func (m *Migrator) Status(ctx context.Context) (map[int64]bool, error) {
-	if err := m.Dialect.EnsureMigrationTable(ctx, m.Conn); err != nil {
+	if err := m.Dialect.EnsureMigrationTable(ctx, m.Conn, m.Schema); err != nil {
 		return nil, err
 	}
-	return m.Dialect.SelectAppliedVersions(ctx, m.Conn)
+	return m.Dialect.SelectAppliedVersions(ctx, m.Conn, m.Schema)
 }
 
 // ApplyUp applies pending up migrations.
@@ -31,7 +39,7 @@ func (m *Migrator) ApplyUp(ctx context.Context, ups []MigrationFile) error {
 		if _, err := m.Conn.ExecContext(ctx, up.SQL); err != nil {
 			return fmt.Errorf("apply up %d failed: %w", up.Version, err)
 		}
-		if err := m.Dialect.InsertVersion(ctx, m.Conn, up.Version); err != nil {
+		if err := m.Dialect.InsertVersion(ctx, m.Conn, m.Schema, up.Version); err != nil {
 			return err
 		}
 	}
@@ -44,7 +52,7 @@ func (m *Migrator) ApplyDown(ctx context.Context, downs []MigrationFile) error {
 		if _, err := m.Conn.ExecContext(ctx, down.SQL); err != nil {
 			return fmt.Errorf("apply down %d failed: %w", down.Version, err)
 		}
-		if err := m.Dialect.DeleteVersion(ctx, m.Conn, down.Version); err != nil {
+		if err := m.Dialect.DeleteVersion(ctx, m.Conn, m.Schema, down.Version); err != nil {
 			return err
 		}
 	}

--- a/internal/migrate/migrator_test.go
+++ b/internal/migrate/migrator_test.go
@@ -60,23 +60,25 @@ func (r mockRows) Err() error   { return nil }
 
 type mockDialect struct{ versions map[int64]bool }
 
-func (d mockDialect) Name() string                                                 { return "mock" }
-func (d mockDialect) EnsureMigrationTable(_ context.Context, _ dialect.Conn) error { return nil }
-func (d mockDialect) SelectAppliedVersions(_ context.Context, _ dialect.Conn) (map[int64]bool, error) {
+func (d mockDialect) Name() string { return "mock" }
+func (d mockDialect) EnsureMigrationTable(_ context.Context, _ dialect.Conn, _ string) error {
+	return nil
+}
+func (d mockDialect) SelectAppliedVersions(_ context.Context, _ dialect.Conn, _ string) (map[int64]bool, error) {
 	return d.versions, nil
 }
-func (d mockDialect) InsertVersion(_ context.Context, _ dialect.Conn, version int64) error {
+func (d mockDialect) InsertVersion(_ context.Context, _ dialect.Conn, _ string, version int64) error {
 	d.versions[version] = true
 	return nil
 }
-func (d mockDialect) DeleteVersion(_ context.Context, _ dialect.Conn, version int64) error {
+func (d mockDialect) DeleteVersion(_ context.Context, _ dialect.Conn, _ string, version int64) error {
 	delete(d.versions, version)
 	return nil
 }
 
 func TestMigratorApplyUpDown(t *testing.T) {
 	versions := map[int64]bool{10: true}
-	migr := NewMigrator(mockDialect{versions: versions}, &mockConn{Versions: versions})
+	migr := NewMigrator(mockDialect{versions: versions}, &mockConn{Versions: versions}, "")
 	ups := []MigrationFile{{Version: 20, Name: "add_col", Direction: "up", SQL: "ALTER"}}
 	if err := migr.ApplyUp(context.Background(), ups); err != nil {
 		t.Fatalf("apply up: %v", err)

--- a/internal/migrate/placeholder_test.go
+++ b/internal/migrate/placeholder_test.go
@@ -1,0 +1,85 @@
+package migrate
+
+import (
+	"testing"
+)
+
+func TestExpandPlaceholdersRequired(t *testing.T) {
+	in := "CREATE TABLE {{schema}}.users(id INT);"
+	out, err := expandPlaceholders(in, "tenant1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "CREATE TABLE tenant1.users(id INT);" {
+		t.Fatalf("mismatch: %s", out)
+	}
+}
+
+func TestExpandPlaceholdersOptionalWithSchema(t *testing.T) {
+	in := "CREATE TABLE {{schema?}}users(id INT);"
+	out, err := expandPlaceholders(in, "tenant1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "CREATE TABLE tenant1.users(id INT);" {
+		t.Fatalf("mismatch: %s", out)
+	}
+}
+
+func TestExpandPlaceholdersOptionalNoSchema(t *testing.T) {
+	in := "CREATE TABLE {{schema?}}users(id INT);"
+	out, err := expandPlaceholders(in, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "CREATE TABLE users(id INT);" {
+		t.Fatalf("mismatch: %s", out)
+	}
+}
+
+func TestExpandPlaceholdersRequiredMissingSchema(t *testing.T) {
+	in := "CREATE TABLE {{schema}}.users(id INT);"
+	if _, err := expandPlaceholders(in, ""); err == nil {
+		t.Fatalf("expected error when schema empty with required placeholder")
+	}
+}
+
+func TestExpandPlaceholdersMultiple(t *testing.T) {
+	in := "INSERT INTO {{schema}}.a SELECT * FROM {{schema}}.b;"
+	out, err := expandPlaceholders(in, "tenant1")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if out != "INSERT INTO tenant1.a SELECT * FROM tenant1.b;" {
+		t.Fatalf("mismatch: %s", out)
+	}
+}
+
+func TestExpandPlaceholdersEscapedRequired(t *testing.T) {
+	in := "CREATE TABLE \\{{schema}}.users(id INT);" // escaped token should remain literal
+	out, err := expandPlaceholders(in, "tenant1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "CREATE TABLE {{schema}}.users(id INT);" {
+		t.Fatalf("mismatch escaped required: %s", out)
+	}
+}
+
+func TestExpandPlaceholdersEscapedOptional(t *testing.T) {
+	in := "CREATE TABLE \\{{schema?}}users(id INT);"
+	out, err := expandPlaceholders(in, "tenant1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "CREATE TABLE {{schema?}}users(id INT);" {
+		t.Fatalf("mismatch escaped optional with schema: %s", out)
+	}
+	out2, err := expandPlaceholders(in, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out2 != "CREATE TABLE {{schema?}}users(id INT);" {
+		t.Fatalf("mismatch escaped optional without schema: %s", out2)
+	}
+}

--- a/tests/integration/postgres/postgres_integration_test.go
+++ b/tests/integration/postgres/postgres_integration_test.go
@@ -87,6 +87,11 @@ func TestPostgresMigrationsIntegration(t *testing.T) {
 	if err := db.PingContext(ctx); err != nil {
 		t.Fatalf("ping: %v", err)
 	}
+	// Setup test schema
+	_, err = db.ExecContext(ctx, `CREATE SCHEMA IF NOT EXISTS test_schema`)
+	if err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
 
 	// ---------------------------------------------------------------------
 	// MIGRATOR: Acquire dialect and create migrator wrapper
@@ -95,7 +100,7 @@ func TestPostgresMigrationsIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get dialect: %v", err)
 	}
-	migr := migrate.NewMigrator(d, dialect.SQLConn{DB: db})
+	migr := migrate.NewMigrator(d, dialect.SQLConn{DB: db}, "test_schema")
 
 	// ---------------------------------------------------------------------
 	// DISCOVERY: Locate migrations directory and parse & validate files


### PR DESCRIPTION
Changes:
- schema cmd line flag
- add schema to dialect interface for handling by dialect implementations (dialects could handle schemas differently)

Note:
Users must still inside their SQL choose the right schema to run against, because this is not done by default?